### PR TITLE
implement Runner.Worker method

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -4,15 +4,23 @@
 package worker
 
 import (
+	"sync"
 	"time"
 
 	"github.com/juju/errors"
+	"github.com/juju/utils/clock"
 	"gopkg.in/tomb.v1"
 )
 
 // DefaultRestartDelay holds the default length of time that a worker
 // will wait between exiting and being restarted by a Runner.
 const DefaultRestartDelay = 3 * time.Second
+
+var (
+	ErrNotFound = errors.New("worker not found")
+	ErrStopped  = errors.New("aborted waiting for worker")
+	ErrDead     = errors.New("worker runner is not running")
+)
 
 // Runner runs a set of workers, restarting them as necessary
 // when they fail.
@@ -24,11 +32,62 @@ type Runner struct {
 	startedc chan startInfo
 
 	params RunnerParams
+
+	// isDying is maintained by the run goroutine.
+	// When it is dying (whether as a result of being killed or due to a
+	// fatal error), all existing workers are killed, no new workers
+	// will be started, and the loop will exit when all existing
+	// workers have stopped.
+	isDying bool
+
+	// finalError is maintained by the run goroutine.
+	// finalError holds the error that will be returned
+	// when the runner finally exits.
+	finalError error
+
+	// mu guards the fields below it. Note that the
+	// run goroutine only locks the mutex when
+	// it changes workers, not when it reads it. It can do this
+	// because it's the only goroutine that changes it.
+	mu sync.Mutex
+
+	// workersChangedCond is notified whenever the
+	// current workers state changes.
+	workersChangedCond sync.Cond
+
+	// workers holds the current set of workers.
+	workers map[string]*workerInfo
+}
+
+// workerInfo holds information on one worker id.
+type workerInfo struct {
+	// worker holds the current Worker instance. This field is
+	// guarded by the Runner.mu mutex so it can be inspected
+	// by Runner.Worker calls.
+	worker Worker
+
+	// The following fields are maintained by the
+	// run goroutine.
+
+	// start holds the function to create the worker.
+	// If this is nil, the worker has been stopped
+	// and will be removed when its goroutine exits.
+	start func() (Worker, error)
+
+	// restartDelay holds the length of time that runWorker
+	// will wait before calling the start function.
+	restartDelay time.Duration
+
+	// stopping holds whether the worker is currently
+	// being killed. The runWorker goroutine will
+	// still exist while this is true.
+	stopping bool
 }
 
 type startReq struct {
 	id    string
 	start func() (Worker, error)
+	reply chan struct{}
 }
 
 type startInfo struct {
@@ -62,8 +121,12 @@ type RunnerParams struct {
 	// RestartDelay holds the length of time the runner will
 	// wait after a worker has exited with a non-fatal error
 	// before it is restarted.
-	// If this is zero, RestartDelay will be used.
+	// If this is zero, DefaultRestartDelay will be used.
 	RestartDelay time.Duration
+
+	// Clock is used for timekeeping. If it's nil, clock.WallClock
+	// will be used.
+	Clock clock.Clock
 }
 
 // NewRunner creates a new Runner.  When a worker finishes, if its error
@@ -90,6 +153,9 @@ func NewRunner(p RunnerParams) *Runner {
 	if p.RestartDelay == 0 {
 		p.RestartDelay = DefaultRestartDelay
 	}
+	if p.Clock == nil {
+		p.Clock = clock.WallClock
+	}
 
 	runner := &Runner{
 		startc:   make(chan startReq),
@@ -97,15 +163,15 @@ func NewRunner(p RunnerParams) *Runner {
 		donec:    make(chan doneInfo),
 		startedc: make(chan startInfo),
 		params:   p,
+		workers:  make(map[string]*workerInfo),
 	}
+	runner.workersChangedCond.L = &runner.mu
 	go func() {
 		defer runner.tomb.Done()
 		runner.tomb.Kill(runner.run())
 	}()
 	return runner
 }
-
-var ErrDead = errors.New("worker runner is not running")
 
 // StartWorker starts a worker running associated with the given id.
 // The startFunc function will be called to create the worker;
@@ -116,8 +182,18 @@ var ErrDead = errors.New("worker runner is not running")
 //
 // StartWorker returns ErrDead if the runner is not running.
 func (runner *Runner) StartWorker(id string, startFunc func() (Worker, error)) error {
+	// Note: we need the reply channel so that when StartWorker
+	// returns, we're guaranteed that the worker is installed
+	// when we return, so Worker will see it if called
+	// immediately afterwards.
+	reply := make(chan struct{})
 	select {
-	case runner.startc <- startReq{id, startFunc}:
+	case runner.startc <- startReq{id, startFunc, reply}:
+		// We're certain to get a reply because the startc channel is synchronous
+		// so if we succeed in sending on it, we know that the run goroutine has entered
+		// the startc arm of the select, and that calls startWorker (which never blocks)
+		// and then immedaitely closes the reply channel.
+		<-reply
 		return nil
 	case <-runner.tomb.Dead():
 	}
@@ -148,117 +224,234 @@ func (runner *Runner) Kill() {
 	runner.tomb.Kill(nil)
 }
 
-type workerInfo struct {
-	start        func() (Worker, error)
-	worker       Worker
-	restartDelay time.Duration
-	stopping     bool
+// Worker returns the current worker for the given id.
+// If a worker has been started with the given id but is
+// not currently available, it will wait until it is available,
+// stopping waiting if it receives a value on the stop channel.
+//
+// If there is no worker started with the given id, Worker
+// will return ErrNotFound. If it was stopped while
+// waiting, Worker will return ErrStopped. If the runner
+// has been killed while waiting, Worker will return ErrDead.
+func (runner *Runner) Worker(id string, stop <-chan struct{}) (Worker, error) {
+	runner.mu.Lock()
+	// getWorker returns the current worker for the id
+	// and reports an ErrNotFound error if the worker
+	// isn't found.
+	getWorker := func() (Worker, error) {
+		info := runner.workers[id]
+		if info == nil {
+			// No entry for the id means the worker
+			// will never become available.
+			return nil, ErrNotFound
+		}
+		return info.worker, nil
+	}
+	if w, err := getWorker(); err != nil || w != nil {
+		// The worker is immediately available  (or we know it's
+		// not going to become available). No need
+		// to block waiting for it.
+		runner.mu.Unlock()
+		return w, err
+	}
+	type workerResult struct {
+		w   Worker
+		err error
+	}
+	wc := make(chan workerResult, 1)
+	stopped := false
+	go func() {
+		defer runner.mu.Unlock()
+		for !stopped {
+			// Note: sync.Condition.Wait unlocks the mutex before
+			// waiting, then locks it again before returning.
+			runner.workersChangedCond.Wait()
+			if w, err := getWorker(); err != nil || w != nil {
+				wc <- workerResult{w, err}
+				return
+			}
+		}
+	}()
+	select {
+	case w := <-wc:
+		if w.err != nil && errors.Cause(w.err) == ErrNotFound {
+			// If it wasn't found, it's possible that's because
+			// the whole thing has shut down, so
+			// check for dying so that we don't mislead
+			// our caller.
+			select {
+			case <-runner.tomb.Dying():
+				return nil, ErrDead
+			default:
+			}
+		}
+		return w.w, w.err
+	case <-runner.tomb.Dying():
+		return nil, ErrDead
+	case <-stop:
+	}
+	// Stop our wait goroutine.
+	// Strictly speaking this can wake up more waiting Worker calls
+	// than needed, but this shouldn't be a problem as in practice
+	// almost all the time Worker should not need to start the
+	// goroutine.
+	runner.mu.Lock()
+	stopped = true
+	runner.mu.Unlock()
+	runner.workersChangedCond.Broadcast()
+	return nil, ErrStopped
 }
 
 func (runner *Runner) run() error {
-	// workers holds the current set of workers.  All workers with a
-	// running goroutine have an entry here.
-	workers := make(map[string]*workerInfo)
-	var finalError error
-
-	// isDying holds whether the runner is currently dying.  When it
-	// is dying (whether as a result of being killed or due to a
-	// fatal error), all existing workers are killed, no new workers
-	// will be started, and the loop will exit when all existing
-	// workers have stopped.
-	isDying := false
 	tombDying := runner.tomb.Dying()
 	for {
-		if isDying && len(workers) == 0 {
-			return finalError
+		if runner.isDying && len(runner.workers) == 0 {
+			return runner.finalError
 		}
 		select {
 		case <-tombDying:
 			logger.Infof("runner is dying")
-			isDying = true
-			killAll(workers)
+			runner.isDying = true
+			runner.killAll()
 			tombDying = nil
+
 		case req := <-runner.startc:
-			if isDying {
-				logger.Infof("ignoring start request for %q when dying", req.id)
-				break
-			}
-			info := workers[req.id]
-			if info == nil {
-				workers[req.id] = &workerInfo{
-					start:        req.start,
-					restartDelay: runner.params.RestartDelay,
-				}
-				go runner.runWorker(0, req.id, req.start)
-				break
-			}
-			if !info.stopping {
-				// The worker is already running, so leave it alone
-				break
-			}
-			// The worker previously existed and is
-			// currently being stopped.  When it eventually
-			// does stop, we'll restart it immediately with
-			// the new start function.
-			info.start = req.start
-			info.restartDelay = 0
+			logger.Debugf("start %q", req.id)
+			runner.startWorker(req)
+			close(req.reply)
+
 		case id := <-runner.stopc:
 			logger.Debugf("stop %q", id)
-			if info := workers[id]; info != nil {
-				killWorker(id, info)
-			}
+			runner.killWorker(id)
+
 		case info := <-runner.startedc:
 			logger.Debugf("%q started", info.id)
-			workerInfo := workers[info.id]
-			workerInfo.worker = info.worker
-			if isDying || workerInfo.stopping {
-				killWorker(info.id, workerInfo)
-			}
+			runner.setWorker(info.id, info.worker)
+
 		case info := <-runner.donec:
 			logger.Debugf("%q done: %v", info.id, info.err)
-			workerInfo := workers[info.id]
-			if !workerInfo.stopping && info.err == nil {
-				logger.Debugf("removing %q from known workers", info.id)
-				delete(workers, info.id)
-				break
-			}
-			if info.err != nil {
-				if runner.params.IsFatal(info.err) {
-					logger.Errorf("fatal %q: %v", info.id, info.err)
-					if finalError == nil || runner.params.MoreImportant(info.err, finalError) {
-						finalError = info.err
-					}
-					delete(workers, info.id)
-					if !isDying {
-						isDying = true
-						killAll(workers)
-					}
-					break
-				} else {
-					logger.Errorf("exited %q: %v", info.id, info.err)
-				}
-			}
-			if workerInfo.start == nil {
-				logger.Debugf("no restart, removing %q from known workers", info.id)
-
-				// The worker has been deliberately stopped;
-				// we can now remove it from the list of workers.
-				delete(workers, info.id)
-				break
-			}
-			go runner.runWorker(workerInfo.restartDelay, info.id, workerInfo.start)
-			workerInfo.restartDelay = runner.params.RestartDelay
+			runner.workerDone(info)
 		}
+		runner.workersChangedCond.Broadcast()
 	}
 }
 
-func killAll(workers map[string]*workerInfo) {
-	for id, info := range workers {
-		killWorker(id, info)
+// startWorker responds when a worker has been started
+// by calling StartWorker.
+func (runner *Runner) startWorker(req startReq) {
+	if runner.isDying {
+		logger.Infof("ignoring start request for %q when dying", req.id)
+		return
+	}
+	info := runner.workers[req.id]
+	if info == nil {
+		runner.mu.Lock()
+		defer runner.mu.Unlock()
+		runner.workers[req.id] = &workerInfo{
+			start:        req.start,
+			restartDelay: runner.params.RestartDelay,
+		}
+		go runner.runWorker(0, req.id, req.start)
+		return
+	}
+	if !info.stopping {
+		// The worker is already running, so leave it alone
+		return
+	}
+	// The worker previously existed and is
+	// currently being stopped.  When it eventually
+	// does stop, we'll restart it immediately with
+	// the new start function.
+	info.start = req.start
+	info.restartDelay = 0
+}
+
+// workerDone responds when a worker has finished or failed
+// to start. It maintains the runner.finalError field and
+// restarts the worker if necessary.
+func (runner *Runner) workerDone(info doneInfo) {
+	workerInfo := runner.workers[info.id]
+	if !workerInfo.stopping && info.err == nil {
+		logger.Debugf("removing %q from known workers", info.id)
+		runner.removeWorker(info.id)
+		return
+	}
+	if info.err != nil {
+		if runner.params.IsFatal(info.err) {
+			logger.Errorf("fatal %q: %v", info.id, info.err)
+			if runner.finalError == nil || runner.params.MoreImportant(info.err, runner.finalError) {
+				runner.finalError = info.err
+			}
+			runner.removeWorker(info.id)
+			if !runner.isDying {
+				runner.isDying = true
+				runner.killAll()
+			}
+			return
+		}
+		logger.Errorf("exited %q: %v", info.id, info.err)
+	}
+	if workerInfo.start == nil {
+		logger.Debugf("no restart, removing %q from known workers", info.id)
+
+		// The worker has been deliberately stopped;
+		// we can now remove it from the list of workers.
+		runner.removeWorker(info.id)
+		return
+	}
+	go runner.runWorker(workerInfo.restartDelay, info.id, workerInfo.start)
+	workerInfo.restartDelay = runner.params.RestartDelay
+}
+
+// removeWorker removes the worker with the given id from the
+// set of current workers. This should only be called when
+// the worker is not running.
+func (runner *Runner) removeWorker(id string) {
+	runner.mu.Lock()
+	delete(runner.workers, id)
+	runner.mu.Unlock()
+}
+
+// setWorker sets the worker associated with the given id.
+func (runner *Runner) setWorker(id string, w Worker) {
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+	info := runner.workers[id]
+	info.worker = w
+	if runner.isDying || info.stopping {
+		// We're dying or the worker has already been
+		// stopped, so kill it already.
+		runner.killWorkerLocked(id)
 	}
 }
 
-func killWorker(id string, info *workerInfo) {
+// killAll stops all the current workers.
+func (runner *Runner) killAll() {
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+	for id := range runner.workers {
+		runner.killWorkerLocked(id)
+	}
+}
+
+// killWorker stops the worker with the given id, and
+// marks it so that it will not start again unless explicitly started
+// with StartWorker.
+func (runner *Runner) killWorker(id string) {
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+	runner.killWorkerLocked(id)
+}
+
+// killWorkerLocked is like killWorker except that it expects
+// the runner.mu mutex to be held already.
+func (runner *Runner) killWorkerLocked(id string) {
+	info := runner.workers[id]
+	if info == nil {
+		return
+	}
+	info.stopping = true
+	info.start = nil
 	if info.worker != nil {
 		logger.Debugf("killing %q", id)
 		info.worker.Kill()
@@ -266,19 +459,19 @@ func killWorker(id string, info *workerInfo) {
 	} else {
 		logger.Debugf("couldn't kill %q, not yet started", id)
 	}
-	info.stopping = true
-	info.start = nil
 }
 
 // runWorker starts the given worker after waiting for the given delay.
 func (runner *Runner) runWorker(delay time.Duration, id string, start func() (Worker, error)) {
 	if delay > 0 {
 		logger.Infof("restarting %q in %v", id, delay)
+		// TODO(rog) provide a way of interrupting this
+		// so that it can be stopped when a worker is removed.
 		select {
 		case <-runner.tomb.Dying():
 			runner.donec <- doneInfo{id, nil}
 			return
-		case <-time.After(delay):
+		case <-runner.params.Clock.After(delay):
 		}
 	}
 	logger.Infof("start %q", id)

--- a/runner_test.go
+++ b/runner_test.go
@@ -5,6 +5,7 @@ package worker_test
 
 import (
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+	"gopkg.in/errgo.v1"
 	"gopkg.in/tomb.v1"
 
 	"gopkg.in/juju/worker.v1"
@@ -22,18 +24,6 @@ type RunnerSuite struct {
 }
 
 var _ = gc.Suite(&RunnerSuite{})
-
-func noneFatal(error) bool {
-	return false
-}
-
-func allFatal(error) bool {
-	return true
-}
-
-func noImportance(err0, err1 error) bool {
-	return false
-}
 
 const (
 	shortWait = 100 * time.Millisecond
@@ -46,7 +36,7 @@ func (*RunnerSuite) TestOneWorkerStart(c *gc.C) {
 		RestartDelay: time.Millisecond,
 	})
 	starter := newTestWorkerStarter()
-	err := runner.StartWorker("id", testWorkerStart(starter))
+	err := runner.StartWorker("id", starter.start)
 	c.Assert(err, jc.ErrorIsNil)
 	starter.assertStarted(c, true)
 
@@ -60,7 +50,7 @@ func (*RunnerSuite) TestOneWorkerFinish(c *gc.C) {
 		RestartDelay: time.Millisecond,
 	})
 	starter := newTestWorkerStarter()
-	err := runner.StartWorker("id", testWorkerStart(starter))
+	err := runner.StartWorker("id", starter.start)
 	c.Assert(err, jc.ErrorIsNil)
 	starter.assertStarted(c, true)
 
@@ -77,7 +67,7 @@ func (*RunnerSuite) TestOneWorkerRestart(c *gc.C) {
 		RestartDelay: time.Millisecond,
 	})
 	starter := newTestWorkerStarter()
-	err := runner.StartWorker("id", testWorkerStart(starter))
+	err := runner.StartWorker("id", starter.start)
 	c.Assert(err, jc.ErrorIsNil)
 	starter.assertStarted(c, true)
 
@@ -99,7 +89,7 @@ func (*RunnerSuite) TestOneWorkerStartFatalError(c *gc.C) {
 	})
 	starter := newTestWorkerStarter()
 	starter.startErr = errors.New("cannot start test task")
-	err := runner.StartWorker("id", testWorkerStart(starter))
+	err := runner.StartWorker("id", starter.start)
 	c.Assert(err, jc.ErrorIsNil)
 	err = runner.Wait()
 	c.Assert(err, gc.Equals, starter.startErr)
@@ -111,7 +101,7 @@ func (*RunnerSuite) TestOneWorkerDieFatalError(c *gc.C) {
 		RestartDelay: time.Millisecond,
 	})
 	starter := newTestWorkerStarter()
-	err := runner.StartWorker("id", testWorkerStart(starter))
+	err := runner.StartWorker("id", starter.start)
 	c.Assert(err, jc.ErrorIsNil)
 	starter.assertStarted(c, true)
 	dieErr := errors.New("error when running")
@@ -127,7 +117,7 @@ func (*RunnerSuite) TestOneWorkerStartStop(c *gc.C) {
 		RestartDelay: time.Millisecond,
 	})
 	starter := newTestWorkerStarter()
-	err := runner.StartWorker("id", testWorkerStart(starter))
+	err := runner.StartWorker("id", starter.start)
 	c.Assert(err, jc.ErrorIsNil)
 	starter.assertStarted(c, true)
 	err = runner.StopWorker("id")
@@ -143,7 +133,7 @@ func (*RunnerSuite) TestOneWorkerStopFatalError(c *gc.C) {
 	})
 	starter := newTestWorkerStarter()
 	starter.stopErr = errors.New("stop error")
-	err := runner.StartWorker("id", testWorkerStart(starter))
+	err := runner.StartWorker("id", starter.start)
 	c.Assert(err, jc.ErrorIsNil)
 	starter.assertStarted(c, true)
 	err = runner.StopWorker("id")
@@ -161,7 +151,7 @@ func (*RunnerSuite) TestOneWorkerStartWhenStopping(c *gc.C) {
 	starter.stopWait = make(chan struct{})
 
 	// Start a worker, and wait for it.
-	err := runner.StartWorker("id", testWorkerStart(starter))
+	err := runner.StartWorker("id", starter.start)
 	c.Assert(err, jc.ErrorIsNil)
 	starter.assertStarted(c, true)
 
@@ -174,7 +164,7 @@ func (*RunnerSuite) TestOneWorkerStartWhenStopping(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// While it's still blocked, try to start another.
-	err = runner.StartWorker("id", testWorkerStart(starter))
+	err = runner.StartWorker("id", starter.start)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Unblock the stopping worker, and check that the task is
@@ -198,7 +188,7 @@ func (*RunnerSuite) TestOneWorkerRestartDelay(c *gc.C) {
 		RestartDelay: delay,
 	})
 	starter := newTestWorkerStarter()
-	err := runner.StartWorker("id", testWorkerStart(starter))
+	err := runner.StartWorker("id", starter.start)
 	c.Assert(err, jc.ErrorIsNil)
 	starter.assertStarted(c, true)
 	starter.die <- fmt.Errorf("non-fatal error")
@@ -231,7 +221,7 @@ func (*RunnerSuite) TestErrorImportance(c *gc.C) {
 	for i := 0; i < 10; i++ {
 		starter := newTestWorkerStarter()
 		starter.stopErr = errorLevel(i)
-		err := runner.StartWorker(id(i), testWorkerStart(starter))
+		err := runner.StartWorker(id(i), starter.start)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	err := runner.StopWorker(id(4))
@@ -266,7 +256,7 @@ func (*RunnerSuite) TestAllWorkersStoppedWhenOneDiesWithFatalError(c *gc.C) {
 	var starters []*testWorkerStarter
 	for i := 0; i < 10; i++ {
 		starter := newTestWorkerStarter()
-		err := runner.StartWorker(fmt.Sprint(i), testWorkerStart(starter))
+		err := runner.StartWorker(fmt.Sprint(i), starter.start)
 		c.Assert(err, jc.ErrorIsNil)
 		starters = append(starters, starter)
 	}
@@ -296,13 +286,13 @@ func (*RunnerSuite) TestFatalErrorWhileStarting(c *gc.C) {
 	// we can delay the start indefinitely.
 	slowStarter.startNotify = make(chan bool)
 
-	err := runner.StartWorker("slow starter", testWorkerStart(slowStarter))
+	err := runner.StartWorker("slow starter", slowStarter.start)
 	c.Assert(err, jc.ErrorIsNil)
 
 	fatalStarter := newTestWorkerStarter()
 	fatalStarter.startErr = fmt.Errorf("a fatal error")
 
-	err = runner.StartWorker("fatal worker", testWorkerStart(fatalStarter))
+	err = runner.StartWorker("fatal worker", fatalStarter.start)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Wait for the runner loop to react to the fatal
@@ -341,13 +331,13 @@ func (*RunnerSuite) TestFatalErrorWhileSelfStartWorker(c *gc.C) {
 			return nil, fmt.Errorf("no worker started")
 		})
 	}
-	err := runner.StartWorker("self starter", testWorkerStart(selfStarter))
+	err := runner.StartWorker("self starter", selfStarter.start)
 	c.Assert(err, jc.ErrorIsNil)
 
 	fatalStarter := newTestWorkerStarter()
 	fatalStarter.startErr = fmt.Errorf("a fatal error")
 
-	err = runner.StartWorker("fatal worker", testWorkerStart(fatalStarter))
+	err = runner.StartWorker("fatal worker", fatalStarter.start)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Wait for the runner loop to react to the fatal
@@ -365,6 +355,250 @@ func (*RunnerSuite) TestFatalErrorWhileSelfStartWorker(c *gc.C) {
 	selfStarter.assertStarted(c, false)
 	err = runner.Wait()
 	c.Assert(err, gc.Equals, fatalStarter.startErr)
+}
+
+func (*RunnerSuite) TestWorkerWithNoWorker(c *gc.C) {
+	runner := worker.NewRunner(worker.RunnerParams{
+		IsFatal:      allFatal,
+		RestartDelay: time.Millisecond,
+	})
+	w, err := runner.Worker("id", nil)
+	c.Assert(errors.Cause(err), gc.Equals, worker.ErrNotFound)
+	c.Assert(w, gc.Equals, nil)
+}
+
+func (*RunnerSuite) TestWorkerWithWorkerImmediatelyAvailable(c *gc.C) {
+	runner := worker.NewRunner(worker.RunnerParams{
+		IsFatal:      allFatal,
+		RestartDelay: time.Millisecond,
+	})
+	starter := newTestWorkerStarter()
+	runner.StartWorker("id", starter.start)
+
+	// Wait long enough to be reasonably confident that the
+	// worker has been started and registered.
+	time.Sleep(10 * time.Millisecond)
+
+	stop := make(chan struct{})
+	close(stop)
+	w, err := runner.Worker("id", stop)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(w, gc.NotNil)
+	c.Assert(w.(*testWorker).starter, gc.Equals, starter)
+}
+
+func (*RunnerSuite) TestWorkerWithWorkerNotImmediatelyAvailable(c *gc.C) {
+	runner := worker.NewRunner(worker.RunnerParams{
+		IsFatal:      allFatal,
+		RestartDelay: time.Millisecond,
+	})
+	defer worker.Stop(runner)
+	starter := newTestWorkerStarter()
+	startCh := make(chan struct{})
+	runner.StartWorker("id", func() (worker.Worker, error) {
+		startCh <- struct{}{}
+		<-startCh
+		return starter.start()
+	})
+	<-startCh
+	// The start function has been called but we know the
+	// worker hasn't been returned yet.
+	wc := make(chan worker.Worker)
+	go func() {
+		w, err := runner.Worker("id", nil)
+		c.Check(err, gc.Equals, nil)
+		wc <- w
+	}()
+	// Sleep long enough that we're pretty sure that Worker
+	// will be blocked.
+	time.Sleep(10 * time.Millisecond)
+	close(startCh)
+	select {
+	case w := <-wc:
+		c.Assert(w, gc.NotNil)
+		c.Assert(w.(*testWorker).starter, gc.Equals, starter)
+	case <-time.After(longWait):
+		c.Fatalf("timed out waiting for worker")
+	}
+}
+
+func (*RunnerSuite) TestWorkerWithAbort(c *gc.C) {
+	t0 := time.Now()
+	clock := testing.NewClock(t0)
+	runner := worker.NewRunner(worker.RunnerParams{
+		IsFatal:      noneFatal,
+		RestartDelay: time.Second,
+		Clock:        clock,
+	})
+	defer worker.Stop(runner)
+	starter := newTestWorkerStarter()
+	starter.startErr = errgo.Newf("test error")
+	runner.StartWorker("id", starter.start)
+
+	// Wait for the runner start waiting for the restart delay.
+	select {
+	case <-clock.Alarms():
+	case <-time.After(longWait):
+		c.Fatalf("runner never slept")
+	}
+
+	errc := make(chan error, 1)
+	stop := make(chan struct{})
+	go func() {
+		w, err := runner.Worker("id", stop)
+		c.Check(w, gc.Equals, nil)
+		errc <- err
+	}()
+	select {
+	case err := <-errc:
+		c.Fatalf("got unexpected result, error %q", err)
+	case <-time.After(shortWait):
+	}
+
+	close(stop)
+	select {
+	case err := <-errc:
+		c.Assert(errors.Cause(err), gc.Equals, worker.ErrStopped)
+	case <-time.After(longWait):
+		c.Fatalf("timed out waiting for worker")
+	}
+}
+
+func (*RunnerSuite) TestWorkerConcurrent(c *gc.C) {
+	runner := worker.NewRunner(worker.RunnerParams{
+		IsFatal:      noneFatal,
+		RestartDelay: time.Microsecond,
+	})
+	defer worker.Stop(runner)
+	const concurrency = 5
+	workers := make([]worker.Worker, concurrency)
+	for i := range workers {
+		w := &errorWorker{
+			err: errors.Errorf("worker %d error", i),
+		}
+		workers[i] = w
+		err := runner.StartWorker(fmt.Sprint("id", i), func() (worker.Worker, error) {
+			return w, nil
+		})
+		c.Assert(err, gc.Equals, nil)
+	}
+	var count int64
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	// Start some concurrent fetchers.
+	for i := range workers {
+		i := i
+		id := fmt.Sprint("id", i)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				atomic.AddInt64(&count, 1)
+				w, err := runner.Worker(id, stop)
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if !c.Check(w, gc.Equals, workers[i], gc.Commentf("worker %d", i)) {
+					return
+				}
+				c.Check(err, gc.Equals, nil)
+			}
+		}()
+	}
+	c.Logf("sleeping")
+	time.Sleep(50 * time.Millisecond)
+	c.Logf("closing stop channel")
+	close(stop)
+	wg.Wait()
+	c.Logf("count %d", count)
+	if count < 5 {
+		c.Errorf("not enough iterations - maybe it's not working (got %d, need 5)", count)
+	}
+}
+
+func (*RunnerSuite) TestWorkerWhenRunnerKilledWhileWaiting(c *gc.C) {
+	t0 := time.Now()
+	clock := testing.NewClock(t0)
+	runner := worker.NewRunner(worker.RunnerParams{
+		IsFatal:      noneFatal,
+		RestartDelay: time.Second,
+		Clock:        clock,
+	})
+	defer worker.Stop(runner)
+	starter := newTestWorkerStarter()
+	starter.startErr = errgo.Newf("test error")
+	runner.StartWorker("id", starter.start)
+
+	// Wait for the runner start waiting for the restart delay.
+	select {
+	case <-clock.Alarms():
+	case <-time.After(longWait):
+		c.Fatalf("runner never slept")
+	}
+
+	errc := make(chan error, 1)
+	go func() {
+		w, err := runner.Worker("id", nil)
+		c.Check(w, gc.Equals, nil)
+		errc <- err
+	}()
+	runner.Kill()
+	select {
+	case err := <-errc:
+		c.Assert(errors.Cause(err), gc.Equals, worker.ErrDead)
+	case <-time.After(longWait):
+		c.Fatalf("timed out waiting for worker")
+	}
+}
+
+func (*RunnerSuite) TestWorkerWhenWorkerRemovedWhileWaiting(c *gc.C) {
+	t0 := time.Now()
+	clock := testing.NewClock(t0)
+	runner := worker.NewRunner(worker.RunnerParams{
+		IsFatal:      noneFatal,
+		RestartDelay: time.Second,
+		Clock:        clock,
+	})
+	defer worker.Stop(runner)
+	starter := newTestWorkerStarter()
+	starter.startErr = errgo.Newf("test error")
+	runner.StartWorker("id", starter.start)
+
+	// Wait for the runner start waiting for the restart delay.
+	select {
+	case <-clock.Alarms():
+	case <-time.After(longWait):
+		c.Fatalf("runner never slept")
+	}
+
+	errc := make(chan error, 1)
+	go func() {
+		w, err := runner.Worker("id", nil)
+		c.Check(w, gc.Equals, nil)
+		errc <- err
+	}()
+	// Wait a little bit until we're pretty sure that the Worker
+	// call will be waiting.
+	time.Sleep(10 * time.Millisecond)
+	err := runner.StopWorker("id")
+	c.Assert(err, gc.Equals, nil)
+
+	// Wait until the runner gets around to restarting
+	// the worker.
+	// TODO(rog) this shouldn't be necessary - the Worker
+	// call should really fail immediately we remove the
+	// worker, but that requires some additional mechanism
+	// to interrupt the runWorker goroutine while it's sleeping,
+	// which doesn't exist yet.
+	clock.Advance(time.Second)
+	select {
+	case err := <-errc:
+		c.Assert(errors.Cause(err), gc.Equals, worker.ErrNotFound)
+	case <-time.After(longWait):
+		c.Fatalf("timed out waiting for worker")
+	}
 }
 
 type testWorkerStarter struct {
@@ -421,18 +655,15 @@ func (starter *testWorkerStarter) assertNeverStarted(c *gc.C, restartDelay time.
 	}
 }
 
-func testWorkerStart(starter *testWorkerStarter) func() (worker.Worker, error) {
-	return func() (worker.Worker, error) {
-		return starter.start()
-	}
-}
-
 func (starter *testWorkerStarter) start() (worker.Worker, error) {
 	if count := atomic.AddInt32(&starter.startCount, 1); count != 1 {
 		panic(fmt.Errorf("unexpected start count %d; expected 1", count))
 	}
 	if starter.startErr != nil {
 		starter.startNotify <- false
+		if count := atomic.AddInt32(&starter.startCount, -1); count != 0 {
+			panic(fmt.Errorf("unexpected start count %d; expected 0", count))
+		}
 		return nil, starter.startErr
 	}
 	task := &testWorker{
@@ -473,4 +704,28 @@ func (t *testWorker) run() {
 	if count := atomic.AddInt32(&t.starter.startCount, -1); count != 0 {
 		panic(fmt.Errorf("unexpected start count %d; expected 0", count))
 	}
+}
+
+// errorWorker holds a worker that immediately dies with an error.g
+type errorWorker struct {
+	err error
+}
+
+func (w errorWorker) Kill() {
+}
+
+func (w errorWorker) Wait() error {
+	return w.err
+}
+
+func noneFatal(error) bool {
+	return false
+}
+
+func allFatal(error) bool {
+	return true
+}
+
+func noImportance(err0, err1 error) bool {
+	return false
 }


### PR DESCRIPTION
There are places in Juju that implement reasonably
complicated wrappers to gain access to running
workers. The Worker method provides access
to the currently running worker within a Runner,
which should reduce the need for such things.