### PR TITLE
Log try again at info level

### DIFF
--- a/dependency/engine.go
+++ b/dependency/engine.go
@@ -629,6 +629,10 @@ func (engine *Engine) gotStopped(name string, err error, resourceLog []resourceA
 			// The task should never run again, and can be removed completely.
 			engine.uninstall(name)
 		default:
+			// TODO(achilleasa): checking against strings is flakey as it can break
+			// if the error message changes in the future; a better approach would
+			// be to refactor juju/errors to include a typed TryAgain error with a
+			// IsTryAgain() helper.
 			logFn := engine.config.Logger.Errorf
 			if strings.Contains(err.Error(), "try again") {
 				// We have been asked to retry; since we will do that anyway

--- a/dependency/engine.go
+++ b/dependency/engine.go
@@ -629,8 +629,16 @@ func (engine *Engine) gotStopped(name string, err error, resourceLog []resourceA
 			// The task should never run again, and can be removed completely.
 			engine.uninstall(name)
 		default:
+			logFn := engine.config.Logger.Errorf
+			if strings.Contains(err.Error(), "try again") {
+				// We have been asked to retry; since we will do that anyway
+				// with no need of human intervention we should not log this
+				// at the ERROR level but rather switch to INFO instead.
+				logFn = engine.config.Logger.Infof
+			}
+
 			// Something went wrong but we don't know what. Try again soon.
-			engine.config.Logger.Errorf("%q manifold worker returned unexpected error: %v", name, err)
+			logFn("%q manifold worker returned unexpected error: %v", name, err)
 			if tracer, ok := err.(stackTracer); ok {
 				engine.config.Logger.Debugf("stack trace:\n%s", strings.Join(tracer.StackTrace(), "\n"))
 			}

--- a/dependency/engine.go
+++ b/dependency/engine.go
@@ -20,6 +20,7 @@ import (
 type Logger interface {
 	Tracef(string, ...interface{})
 	Debugf(string, ...interface{})
+	Infof(string, ...interface{})
 	Errorf(string, ...interface{})
 }
 


### PR DESCRIPTION
This PR addresses https://bugs.launchpad.net/juju/+bug/1812980 by adding extra logic to the handling of unexpected engine-stop errors. 

Error messages are scanned for the presence of a `try again` string; if found, the code reports the error at the `INFO` log level.
