### PR TITLE
Treat any error as potential for exponential backoff.

### DIFF
--- a/dependency/engine.go
+++ b/dependency/engine.go
@@ -552,7 +552,6 @@ func (engine *Engine) gotStarted(name string, worker worker.Worker, resourceLog 
 		worker.Kill()
 	default:
 		// It's fine to use this worker; update info and copy back.
-		engine.config.Logger.Debugf("%q manifold worker started", name)
 		info.worker = worker
 		info.starting = false
 		info.startCount++

--- a/dependency/engine.go
+++ b/dependency/engine.go
@@ -387,8 +387,6 @@ func (engine *Engine) requestStart(name string, delay time.Duration) {
 	// ...then update the info, copy it back to the engine, and start a worker
 	// goroutine based on current known state.
 	info.starting = true
-	// Don't record the first attempt during manifold install.
-	// This is to avoid the extra backoff on the first failure.
 	info.startAttempts++
 	info.err = nil
 	info.abort = make(chan struct{})
@@ -596,7 +594,6 @@ func (engine *Engine) gotStopped(name string, err error, resourceLog []resourceA
 		engine.config.Logger.Debugf("%q manifold worker stopped: %v", name, err)
 		now := engine.config.Clock.Now().UTC()
 		timeSinceStarted := now.Sub(info.startedTime)
-		// TODO(jam): 2019-05-09 Config the time-running-before-backoff
 		// startedTime is Zero, then we haven't even successfully started, so treat
 		// it the same way as a successful start followed by a quick failure.
 		if info.startedTime.IsZero() || timeSinceStarted < engine.config.BackoffResetTime {

--- a/dependency/engine_test.go
+++ b/dependency/engine_test.go
@@ -859,7 +859,13 @@ func (s *EngineSuite) TestBackoffFactorOnError(c *gc.C) {
 		c.Assert(clock.WaitAdvance(800*time.Millisecond, testing.ShortWait, 1), jc.ErrorIsNil)
 		mh.AssertStartAttempt(c)
 
-		c.Logf("running for 2 minutes")
+		// We need to advance the clock after we have recorded startTime, which
+		// means we need to wait for the engine to notice the started event,
+		// process it, and be ready to process the next event. Installing another
+		// manifold is done in the same loop.
+		err = engine.Install("task2", mh.Manifold())
+		c.Assert(err, jc.ErrorIsNil)
+
 		// Now advance longer than the BackoffResetTime, indicating the
 		// worker was running successfully for "long enough" before we
 		// trigger a failure

--- a/dependency/util_test.go
+++ b/dependency/util_test.go
@@ -43,13 +43,16 @@ func (fix *engineFixture) worstErrorFunc() dependency.WorstErrorFunc {
 
 func (fix *engineFixture) defaultEngineConfig(clock clock.Clock) dependency.EngineConfig {
 	return dependency.EngineConfig{
-		IsFatal:     fix.isFatalFunc(),
-		WorstError:  fix.worstErrorFunc(),
-		Filter:      fix.filter, // can be nil anyway
-		ErrorDelay:  testing.ShortWait / 2,
-		BounceDelay: testing.ShortWait / 10,
-		Clock:       clock,
-		Logger:      loggo.GetLogger("test"),
+		IsFatal:          fix.isFatalFunc(),
+		WorstError:       fix.worstErrorFunc(),
+		Filter:           fix.filter, // can be nil anyway
+		ErrorDelay:       testing.ShortWait / 2,
+		BounceDelay:      testing.ShortWait / 10,
+		BackoffFactor:    0,
+		MaxDelay:         time.Second,
+		BackoffResetTime: time.Minute,
+		Clock:            clock,
+		Logger:           loggo.GetLogger("test"),
 	}
 }
 


### PR DESCRIPTION
Rather than only backing off when Start fails, use a timeout for any
error within a window of starting ends up being treated as a potential
for exponential backoff.
We need to decide what a reasonable length of time is before we decide
that the worker was effectively working-as-normal and should be
restarted immediately.

https://bugs.launchpad.net/juju/+bug/1827664