### PR TITLE
Remove the resource-log from the Report.

### DIFF
--- a/dependency/engine.go
+++ b/dependency/engine.go
@@ -283,9 +283,8 @@ func (engine *Engine) manifoldsReport() map[string]interface{} {
 	manifolds := map[string]interface{}{}
 	for name, info := range engine.current {
 		report := map[string]interface{}{
-			KeyState:       info.state(),
-			KeyInputs:      engine.manifolds[name].Inputs,
-			KeyResourceLog: resourceLogReport(info.resourceLog),
+			KeyState:  info.state(),
+			KeyInputs: engine.manifolds[name].Inputs,
 		}
 		if info.startCount > 0 {
 			report[KeyStartCount] = info.startCount

--- a/dependency/reporter.go
+++ b/dependency/reporter.go
@@ -52,11 +52,6 @@ const (
 	// KeyInputs holds the names of the manifolds on which this one depends.
 	KeyInputs = "inputs"
 
-	// KeyResourceLog holds a slice representing the calls the current worker
-	// made to its getResource func; the type of the output param; and any
-	// error encountered.
-	KeyResourceLog = "resource-log"
-
 	// KeyName holds the name of some resource.
 	KeyName = "name"
 

--- a/dependency/reporter_test.go
+++ b/dependency/reporter_test.go
@@ -98,11 +98,10 @@ func (s *ReportSuite) TestReportStopping(c *gc.C) {
 			"state": "stopping",
 			"manifolds": map[string]interface{}{
 				"task": map[string]interface{}{
-					"state":        "stopping",
-					"start-count":  1,
-					"started":      "2018-08-07 13:15:42",
-					"inputs":       ([]string)(nil),
-					"resource-log": []map[string]interface{}{},
+					"state":       "stopping",
+					"start-count": 1,
+					"started":     "2018-08-07 13:15:42",
+					"inputs":      ([]string)(nil),
 					"report": map[string]interface{}{
 						"key1": "hello there",
 					},
@@ -129,11 +128,10 @@ func (s *ReportSuite) TestReportInputs(c *gc.C) {
 			"state": "started",
 			"manifolds": map[string]interface{}{
 				"task": map[string]interface{}{
-					"state":        "started",
-					"start-count":  1,
-					"started":      "2018-08-07 13:15:42",
-					"inputs":       ([]string)(nil),
-					"resource-log": []map[string]interface{}{},
+					"state":       "started",
+					"start-count": 1,
+					"started":     "2018-08-07 13:15:42",
+					"inputs":      ([]string)(nil),
 					"report": map[string]interface{}{
 						"key1": "hello there",
 					},
@@ -143,10 +141,6 @@ func (s *ReportSuite) TestReportInputs(c *gc.C) {
 					"start-count": 1,
 					"started":     "2018-08-07 13:15:42",
 					"inputs":      []string{"task"},
-					"resource-log": []map[string]interface{}{{
-						"name": "task",
-						"type": "<nil>",
-					}},
 					"report": map[string]interface{}{
 						"key1": "hello there",
 					},
@@ -173,11 +167,6 @@ func (s *ReportSuite) TestReportError(c *gc.C) {
 					"state":  "stopped",
 					"error":  `"missing" not running: dependency not available`,
 					"inputs": []string{"missing"},
-					"resource-log": []map[string]interface{}{{
-						"name":  "missing",
-						"type":  "<nil>",
-						"error": `"missing" not running: dependency not available`,
-					}},
 				},
 			},
 		})


### PR DESCRIPTION
The resource-log never really adds any value when trying to look at what is going on the in the engine using the Report method. It is just noise, so removing it.