### PR TITLE
[JUJU-290] Metrics: Allow the collection of worker lifecycle events (backport)

### DIFF
--- a/dependency/engine.go
+++ b/dependency/engine.go
@@ -79,6 +79,11 @@ type EngineConfig struct {
 	// Clock will be a wall clock for production, and test clocks for tests.
 	Clock Clock
 
+	// Metrics defines a type for reporting the workers lifecycle in the engine.
+	// Currently this only supports recording of the number of starts for a
+	// given worker, but could be expanded to record other measurements.
+	Metrics Metrics
+
 	// Logger is used to provide an implementation for where the logging
 	// messages go for the runner.
 	Logger Logger
@@ -110,6 +115,9 @@ func (config *EngineConfig) Validate() error {
 	if config.Clock == nil {
 		return errors.NotValidf("missing Clock")
 	}
+	if config.Metrics == nil {
+		return errors.NotValidf("missing Metrics")
+	}
 	if config.Logger == nil {
 		return errors.NotValidf("missing Logger")
 	}
@@ -136,6 +144,8 @@ func NewEngine(config EngineConfig) (*Engine, error) {
 		started: make(chan startedTicket),
 		stopped: make(chan stoppedTicket),
 		report:  make(chan reportTicket),
+
+		metrics: config.Metrics,
 	}
 	engine.tomb.Go(engine.loop)
 	return engine, nil
@@ -175,6 +185,10 @@ type Engine struct {
 	started chan startedTicket
 	stopped chan stoppedTicket
 	report  chan reportTicket
+
+	// Metrics is used to record the number of changes a given worker has
+	// performed.
+	metrics Metrics
 }
 
 // loop serializes manifold install operations and worker start/stop notifications.
@@ -563,6 +577,9 @@ func (engine *Engine) gotStarted(name string, worker worker.Worker, resourceLog 
 		info.startedTime = engine.config.Clock.Now().UTC()
 		engine.config.Logger.Debugf("%q manifold worker started at %v", name, info.startedTime)
 		engine.current[name] = info
+
+		// Record the start of a worker.
+		engine.metrics.RecordStart(name)
 
 		// Any manifold that declares this one as an input needs to be restarted.
 		engine.bounceDependents(name)

--- a/dependency/engine_test.go
+++ b/dependency/engine_test.go
@@ -708,6 +708,10 @@ func (s *EngineSuite) TestConfigValidate(c *gc.C) {
 		}, "missing Clock not valid",
 	}, {
 		func(config *dependency.EngineConfig) {
+			config.Metrics = nil
+		}, "missing Metrics not valid",
+	}, {
+		func(config *dependency.EngineConfig) {
 			config.Logger = nil
 		}, "missing Logger not valid",
 	}}
@@ -720,6 +724,7 @@ func (s *EngineSuite) TestConfigValidate(c *gc.C) {
 			ErrorDelay:  time.Second,
 			BounceDelay: time.Second,
 			Clock:       clock.WallClock,
+			Metrics:     dependency.DefaultMetrics(),
 			Logger:      loggo.GetLogger("test"),
 		}
 		test.breakConfig(&config)

--- a/dependency/metrics.go
+++ b/dependency/metrics.go
@@ -1,0 +1,21 @@
+// Copyright 2021 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package dependency
+
+// Metrics defines a type for recording the worker life cycle in the dependency
+// engine.
+type Metrics interface {
+	RecordStart(name string)
+}
+
+// noopMetrics gives a metric that doesn't do anything.
+type noopMetric struct{}
+
+func (noopMetric) RecordStart(name string) {}
+
+// DefaultMetrics returns a metrics implementation that performs no operations,
+// but can be used for scenarios where metrics output isn't required.
+func DefaultMetrics() Metrics {
+	return noopMetric{}
+}

--- a/dependency/util_test.go
+++ b/dependency/util_test.go
@@ -52,6 +52,7 @@ func (fix *engineFixture) defaultEngineConfig(clock clock.Clock) dependency.Engi
 		MaxDelay:         time.Second,
 		BackoffResetTime: time.Minute,
 		Clock:            clock,
+		Metrics:          dependency.DefaultMetrics(),
 		Logger:           loggo.GetLogger("test"),
 	}
 }


### PR DESCRIPTION
The following starts to expose the events of a worker, so that we can
better observe the changes of a juju instance. The only one that seems
relevant at the moment, is how many times a start is done, but this can
easily be expanded at a later date.

I chose RecordStart to be explicit, rather than picking Record with a
state. Although changing that in the future should be really easy.