### PR TITLE
[JUJU-3398] Catacomb context support

### DIFF
--- a/catacomb/catacomb.go
+++ b/catacomb/catacomb.go
@@ -4,6 +4,7 @@
 package catacomb
 
 import (
+	"context"
 	"fmt"
 	"runtime/debug"
 	"strings"
@@ -211,12 +212,22 @@ func (catacomb *Catacomb) Err() error {
 	return catacomb.tomb.Err()
 }
 
+// Context returns a context that is a copy of the provided parent context with
+// a replaced Done channel that is closed when either the catacomb is dying or
+// the parent is cancelled.
+//
+// If parent is nil, it defaults to the empty background context.
+func (catacomb *Catacomb) Context(parent context.Context) context.Context {
+	return catacomb.tomb.Context(parent)
+}
+
 // Kill kills the Catacomb's internal tomb with the supplied error, or one
 // derived from it.
-//  * if it's caused by this catacomb's ErrDying, it passes on tomb.ErrDying.
-//  * if it's tomb.ErrDying, or caused by another catacomb's ErrDying, it passes
-//    on a new error complaining about the misuse.
-//  * all other errors are passed on unmodified.
+//   - if it's caused by this catacomb's ErrDying, it passes on tomb.ErrDying.
+//   - if it's tomb.ErrDying, or caused by another catacomb's ErrDying, it passes
+//     on a new error complaining about the misuse.
+//   - all other errors are passed on unmodified.
+//
 // It's always safe to call Kill, but errors passed to Kill after the catacomb
 // is dead will be ignored.
 func (catacomb *Catacomb) Kill(err error) {


### PR DESCRIPTION
Adds context support to the catacomb type. In reality this just calls the tomb context method. By exposing the context method we can then tie a context to the lifecycle of a catacomb.

The only difference between a tomb and a catacomb in relation to a context is that a catacomb doesn't expose the concept of a parent context. The tomb type allows you to create a tomb from a context (WithContext), which will be the root context for the tomb. Instead a catacomb will currently fallback to a context.Background. We could provide a WithContext for a catacomb, I'm unsure if that functionality is required right now?

---

The tests were lifted and modified from the tomb test package, which ensures that we don't deviate from the tomb package in the future.