### PR TITLE
Prevent start worker whilst dying

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -230,7 +230,7 @@ func (runner *Runner) StartWorker(id string, startFunc func() (Worker, error)) e
 		// the startc arm of the select, and that calls startWorker (which never blocks)
 		// and then immediately sends any error to the reply channel.
 		return <-reply
-	case <-runner.tomb.Dead():
+	case <-runner.tomb.Dying():
 	}
 	return ErrDead
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -346,7 +346,7 @@ func (*RunnerSuite) TestPreventWorkerStartOnDying(c *gc.C) {
 		atomic.AddInt64(&attempt, 1)
 		return nil, nil
 	})
-	c.Assert(err, gc.Equals, worker.ErrDead)
+	c.Assert(err, gc.Equals, worker.ErrDying)
 	c.Assert(atomic.LoadInt64(&attempt), gc.Equals, int64(0))
 }
 


### PR DESCRIPTION
The start worker method only checks to see if the tomb is dead in the select statement. This has the potential of doing additional work of attempting to create a worker whilst it is dying.

By changing this to tomb dying state, this prevents sending the start request to the start channel. This should reduce the busy work that a runner will do once it starts to shutdown. With the benifit of stopping the runner in a quickly, as the runner no longer need to process each request whilst dying.