### PR TITLE
[JUJU-4012] Allow runners to stop based on an error

### DIFF
--- a/runner_test.go
+++ b/runner_test.go
@@ -306,12 +306,12 @@ func (*RunnerSuite) TestOneWorkerRestartDelay(c *gc.C) {
 	c.Assert(worker.Stop(runner), gc.IsNil)
 }
 
-func (*RunnerSuite) TestOneWorkerIsStoppable(c *gc.C) {
+func (*RunnerSuite) TestOneWorkerShouldRestart(c *gc.C) {
 	const delay = 100 * time.Millisecond
 	runner := worker.NewRunner(worker.RunnerParams{
-		IsFatal:      noneFatal,
-		IsStoppable:  func(err error) bool { return true },
-		RestartDelay: delay,
+		IsFatal:       noneFatal,
+		ShouldRestart: func(err error) bool { return false },
+		RestartDelay:  delay,
 	})
 	starter := newTestWorkerStarter()
 	err := runner.StartWorker("id", starter.start)

--- a/runner_test.go
+++ b/runner_test.go
@@ -320,6 +320,9 @@ func (*RunnerSuite) TestOneWorkerIsStoppable(c *gc.C) {
 	starter.die <- fmt.Errorf("non-fatal error")
 	starter.assertStarted(c, false)
 	starter.assertNeverStarted(c, delay)
+	w, err := runner.Worker("id", nil)
+	c.Assert(err, jc.Satisfies, errors.IsNotFound)
+	c.Assert(w, gc.Equals, nil)
 	c.Assert(worker.Stop(runner), gc.IsNil)
 }
 


### PR DESCRIPTION
The following allows a runner to be stopped based on an error message. This makes it much more flexible in the phase of workers stopping based on an error, yet we don't want them to restart for some reason.

In addition, returning nil from some workers in the expectation that will ensure a clean kill is also mistaken. If using a runner to ensure workers stay running, returning nil will just cause that worker to restart after the delay. This probably isn't what we want in all scenarios. Adding this check allows us to add logic based on returned error cases to control the lifecycle of the worker.

This shouldn't require a new version either. Although we're adding a new field to the RunnerParams. We're backward compatible by ensuring that IsStoppable returns false by default. 