### PR TITLE
Expose the worker names

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -303,6 +303,20 @@ func (runner *Runner) Worker(id string, abort <-chan struct{}) (Worker, error) {
 	return w, err
 }
 
+// WorkerNames returns the names of the current workers.
+// They are returned in no particular order and they might not exists when
+// the Worker request is made.
+func (runner *Runner) WorkerNames() []string {
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+
+	names := make([]string, 0, len(runner.workers))
+	for name := range runner.workers {
+		names = append(names, name)
+	}
+	return names
+}
+
 func (runner *Runner) workerInfo(id string, abort <-chan struct{}) (Worker, <-chan struct{}, error) {
 	runner.mu.Lock()
 	// getWorker returns the current worker for the id


### PR DESCRIPTION
The following exposes the worker names for a given runner. This is useful to iterate over the workers. This doesn't check to see if the workers are not dead/found, it just reports the actual workers available to it.

This rationale for this, is to prevent the divergent sources of truth. The runner knows exactly which runners it is tracking and removes them after death. Attempting to track when each runner is dead from the outside isn't that easy, if some can crash internally or be removed from the runner directly. Instead of playing a guessing game, just look it up.

----

Note: this will need to be merged forward to v4 once landed.