### PR TITLE
feat!: handle context cancellation in `Report`

### DIFF
--- a/dependency/engine.go
+++ b/dependency/engine.go
@@ -209,7 +209,7 @@ func (engine *Engine) loop() error {
 			}
 		case ticket := <-engine.report:
 			// This is safe so long as the Report method reads the result.
-			ticket.result <- engine.liveReport()
+			ticket.result <- engine.liveReport(ticket.ctx)
 		case ticket := <-engine.install:
 			// This is safe so long as the Install method reads the result.
 			ticket.result <- engine.gotInstall(ticket.name, ticket.manifold)
@@ -244,20 +244,26 @@ func (engine *Engine) Wait() error {
 }
 
 // Report is part of the Reporter interface.
-func (engine *Engine) Report() map[string]interface{} {
+func (engine *Engine) Report(ctx context.Context) map[string]interface{} {
 	report := make(chan map[string]interface{})
 	select {
-	case engine.report <- reportTicket{report}:
-		// This is safe so long as the loop sends a result.
-		return <-report
+	case <-ctx.Done():
+		return engine.errorReport(ctx.Err())
+	case engine.report <- reportTicket{ctx: ctx, result: report}:
+		return engine.waitForReport(ctx, report)
 	case <-engine.tomb.Dead():
+		if ctx.Err() != nil {
+			// Avoid flakiness if both context is canceled and tomb is dying
+			// at the same time
+			return engine.errorReport(ctx.Err())
+		}
 		// Note that we don't abort on Dying as we usually would; the
 		// oneShotDying approach in loop means that it can continue to
 		// process requests until the last possible moment. Only once
 		// loop has exited do we fall back to this report.
 		report := map[string]interface{}{
 			KeyState:     "stopped",
-			KeyManifolds: engine.manifoldsReport(),
+			KeyManifolds: engine.manifoldsReport(ctx),
 		}
 		if err := engine.Wait(); err != nil {
 			report[KeyError] = err.Error()
@@ -266,9 +272,30 @@ func (engine *Engine) Report() map[string]interface{} {
 	}
 }
 
+// errorReport generates a map containing error details using the provided error.
+func (engine *Engine) errorReport(err error) map[string]interface{} {
+	return map[string]interface{}{
+		KeyError: err.Error(),
+	}
+}
+
+// waitForReport waits for a report from the provided channel or exits early if the context is canceled.
+func (engine *Engine) waitForReport(ctx context.Context, report <-chan map[string]interface{}) map[string]interface{} {
+	select {
+	case <-ctx.Done():
+		// We already posted the ticket which means that the engine is dealing
+		// with it. We need to flush the report channel to avoid a deadlock in
+		// the engine.
+		go func() { <-report }()
+		return engine.errorReport(ctx.Err())
+	case result := <-report:
+		return result
+	}
+}
+
 // liveReport collects and returns information about the engine, its manifolds,
 // and their workers. It must only be called from the loop goroutine.
-func (engine *Engine) liveReport() map[string]interface{} {
+func (engine *Engine) liveReport(ctx context.Context) map[string]interface{} {
 	var reportError error
 	state := "started"
 	if engine.isDying() {
@@ -281,7 +308,7 @@ func (engine *Engine) liveReport() map[string]interface{} {
 	}
 	report := map[string]interface{}{
 		KeyState:     state,
-		KeyManifolds: engine.manifoldsReport(),
+		KeyManifolds: engine.manifoldsReport(ctx),
 	}
 	if reportError != nil {
 		report[KeyError] = reportError.Error()
@@ -292,8 +319,9 @@ func (engine *Engine) liveReport() map[string]interface{} {
 // manifoldsReport collects and returns information about the engine's manifolds
 // and their workers. Until the tomb is Dead, it should only be called from the
 // loop goroutine; after that, it's goroutine-safe.
-func (engine *Engine) manifoldsReport() map[string]interface{} {
+func (engine *Engine) manifoldsReport(ctx context.Context) map[string]interface{} {
 	manifolds := map[string]interface{}{}
+	// prepopulate map with expected reports
 	for name, info := range engine.current {
 		report := map[string]interface{}{
 			KeyState:  info.state(),
@@ -310,7 +338,27 @@ func (engine *Engine) manifoldsReport() map[string]interface{} {
 		}
 		if reporter, ok := info.worker.(Reporter); ok {
 			if reporter != engine {
-				report[KeyReport] = reporter.Report()
+				report[KeyReportStatus] = "Waiting for worker to report..."
+			}
+		}
+		manifolds[name] = report
+	}
+
+	// Call each reporter
+	for name, info := range engine.current {
+		if ctx.Err() != nil {
+			return manifolds
+		}
+		report := manifolds[name].(map[string]interface{})
+		if reporter, ok := info.worker.(Reporter); ok {
+			if reporter != engine {
+				if reported := reporter.Report(ctx); reported != nil {
+					report[KeyReport] = reported
+				}
+				delete(report, KeyReportStatus)
+				if ctx.Err() != nil {
+					report[KeyReportStatus] = ctx.Err().Error()
+				}
 			}
 		}
 		manifolds[name] = report
@@ -841,5 +889,6 @@ type stoppedTicket struct {
 // reportTicket is used by the engine to notify the loop that a status report
 // should be generated.
 type reportTicket struct {
+	ctx    context.Context
 	result chan map[string]interface{}
 }

--- a/dependency/reporter.go
+++ b/dependency/reporter.go
@@ -3,18 +3,22 @@
 
 package dependency
 
+import "context"
+
 // Reporter defines an interface for extracting human-relevant information
 // from a worker.
 type Reporter interface {
 
 	// Report returns a map describing the state of the receiver. It is expected
-	// to be goroutine-safe.
+	// to be goroutine-safe. The context can be used to cancel a long-running
+	// report; implementations should respect ctx.Done() and return an empty map
+	// with a KeyError if the context is cancelled before the report is complete.
 	//
 	// It is polite and helpful to use the Key* constants and conventions defined
 	// and described in this package, where appropriate, but that's for the
 	// convenience of the humans that read the reports; we don't and shouldn't
 	// have any code that depends on particular Report formats.
-	Report() map[string]interface{}
+	Report(ctx context.Context) map[string]interface{}
 }
 
 // The Key constants describe the constant features of an Engine's Report.
@@ -48,6 +52,12 @@ const (
 	// KeyReport holds an arbitrary map of information returned by a manifold
 	// Worker that is also a Reporter.
 	KeyReport = "report"
+
+	// KeyReportStatus holds any error encountered when trying to generate the
+	// report. It is expected to be nil unless the report generation get
+	// canceled. In this case its value may be the error from context generation,
+	// or a string stating that the worker was waiting the report to be generated.
+	KeyReportStatus = "report-status"
 
 	// KeyInputs holds the names of the manifolds on which this one depends.
 	KeyInputs = "inputs"

--- a/dependency/reporter_test.go
+++ b/dependency/reporter_test.go
@@ -4,6 +4,7 @@
 package dependency_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock/testclock"
@@ -37,7 +38,7 @@ func (s *ReportSuite) SetUpTest(c *gc.C) {
 
 func (s *ReportSuite) TestReportStarted(c *gc.C) {
 	s.fix.run(c, func(engine *dependency.Engine) {
-		report := engine.Report()
+		report := engine.Report(context.Background())
 		c.Check(report, jc.DeepEquals, map[string]interface{}{
 			"state":     "started",
 			"manifolds": map[string]interface{}{},
@@ -48,7 +49,7 @@ func (s *ReportSuite) TestReportStarted(c *gc.C) {
 func (s *ReportSuite) TestReportStopped(c *gc.C) {
 	s.fix.run(c, func(engine *dependency.Engine) {
 		workertest.CleanKill(c, engine)
-		report := engine.Report()
+		report := engine.Report(context.Background())
 		c.Check(report, jc.DeepEquals, map[string]interface{}{
 			"state":     "stopped",
 			"manifolds": map[string]interface{}{},
@@ -89,7 +90,7 @@ func (s *ReportSuite) TestReportStopping(c *gc.C) {
 
 		var report map[string]interface{}
 		for i := 0; i < 3; i++ {
-			report = engine.Report()
+			report = engine.Report(context.Background())
 			if isTaskStopping(report) {
 				break
 			}
@@ -124,7 +125,7 @@ func (s *ReportSuite) TestReportInputs(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		mh2.AssertOneStart(c)
 
-		report := engine.Report()
+		report := engine.Report(context.Background())
 		c.Check(report, jc.DeepEquals, map[string]interface{}{
 			"state": "started",
 			"manifolds": map[string]interface{}{
@@ -160,7 +161,7 @@ func (s *ReportSuite) TestReportError(c *gc.C) {
 		mh1.AssertNoStart(c)
 
 		workertest.CleanKill(c, engine)
-		report := engine.Report()
+		report := engine.Report(context.Background())
 		c.Check(report, jc.DeepEquals, map[string]interface{}{
 			"state": "stopped",
 			"manifolds": map[string]interface{}{
@@ -170,6 +171,32 @@ func (s *ReportSuite) TestReportError(c *gc.C) {
 					"inputs": []string{"missing"},
 				},
 			},
+		})
+	})
+}
+
+func (s *ReportSuite) TestReportCancelledContextWhileRunning(c *gc.C) {
+	s.fix.run(c, func(engine *dependency.Engine) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		report := engine.Report(ctx)
+		c.Check(report, jc.DeepEquals, map[string]interface{}{
+			"error": "context canceled",
+		})
+	})
+}
+
+func (s *ReportSuite) TestReportCancelledContextWhenStopped(c *gc.C) {
+	s.fix.run(c, func(engine *dependency.Engine) {
+		workertest.CleanKill(c, engine)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		report := engine.Report(ctx)
+		c.Check(report, jc.DeepEquals, map[string]interface{}{
+			"error": "context canceled",
 		})
 	})
 }

--- a/dependency/util_test.go
+++ b/dependency/util_test.go
@@ -215,7 +215,7 @@ func (w *minimalWorker) Wait() error {
 	return w.tomb.Wait()
 }
 
-func (w *minimalWorker) Report() map[string]interface{} {
+func (w *minimalWorker) Report(ctx context.Context) map[string]interface{} {
 	return map[string]interface{}{
 		"key1": "hello there",
 	}

--- a/reporter.go
+++ b/reporter.go
@@ -3,18 +3,23 @@
 
 package worker
 
+import "context"
+
 // Reporter defines an interface for extracting human-relevant information
 // from a worker.
 type Reporter interface {
 
 	// Report returns a map describing the state of the receiver. It is expected
-	// to be goroutine-safe.
+	// to be goroutine-safe. The context can be used to cancel a long-running
+	// report; implementations should respect ctx.Done() and, if the context is
+	// canceled before the report is complete, return a map containing only
+	// KeyError describing the cancellation.
 	//
 	// It is polite and helpful to use the Key* constants and conventions defined
 	// and described in this package, where appropriate, but that's for the
 	// convenience of the humans that read the reports; we don't and shouldn't
 	// have any code that depends on particular Report formats.
-	Report() map[string]interface{}
+	Report(ctx context.Context) map[string]interface{}
 }
 
 // The Key constants describe the constant features of an Engine's Report.
@@ -31,4 +36,10 @@ const (
 
 	// KeyLastStart holds the time of when the worker was last started.
 	KeyLastStart = "started"
+
+	// KeyReportStatus holds any error encountered when trying to generate the
+	// report. It is expected to be nil unless the report generation get
+	// canceled. In this case its value may be the error from context generation,
+	// or a string stating that the worker was waiting the report to be generated.
+	KeyReportStatus = "report-status"
 )

--- a/runner.go
+++ b/runner.go
@@ -740,15 +740,22 @@ func (runner *Runner) runWorker(ctx context.Context, delay time.Duration, id str
 }
 
 type reporter interface {
-	Report() map[string]interface{}
+	Report(ctx context.Context) map[string]interface{}
 }
 
 // Report implements Reporter.
-func (runner *Runner) Report() map[string]interface{} {
+func (runner *Runner) Report(ctx context.Context) map[string]interface{} {
+	if ctx.Err() != nil {
+		return nil
+	}
 	workers := make(map[string]interface{})
 	runner.mu.Lock()
 	defer runner.mu.Unlock()
+	// Populate the workers map with the current state of the workers.
 	for id, info := range runner.workers {
+		if ctx.Err() != nil {
+			return nil
+		}
 		worker := info.worker
 		workerReport := map[string]interface{}{
 			KeyState: info.status(),
@@ -757,9 +764,26 @@ func (runner *Runner) Report() map[string]interface{} {
 			workerReport[KeyLastStart] = info.started.Format("2006-01-02 15:04:05")
 		}
 		if worker != nil {
+			if _, ok := worker.(reporter); ok {
+				workerReport[KeyReportStatus] = "Waiting for worker to eventually report..."
+			}
+		}
+		workers[id] = workerReport
+	}
+	for id, info := range runner.workers {
+		if ctx.Err() != nil {
+			break
+		}
+		worker := info.worker
+		workerReport := workers[id].(map[string]interface{})
+		if worker != nil {
 			if r, ok := worker.(reporter); ok {
-				if report := r.Report(); len(report) > 0 {
+				if report := r.Report(ctx); len(report) > 0 {
 					workerReport[KeyReport] = report
+				}
+				delete(workerReport, KeyReportStatus)
+				if ctx.Err() != nil {
+					workerReport[KeyReportStatus] = ctx.Err().Error()
 				}
 			}
 		}

--- a/runner_test.go
+++ b/runner_test.go
@@ -869,7 +869,7 @@ func (*RunnerSuite) TestRunnerReport(c *gc.C) {
 		}
 	}
 
-	report := runner.Report()
+	report := runner.Report(context.Background())
 	c.Assert(report, jc.DeepEquals, map[string]interface{}{
 		"workers": map[string]interface{}{
 			"worker-0": map[string]interface{}{
@@ -899,6 +899,21 @@ func (*RunnerSuite) TestRunnerReport(c *gc.C) {
 				"started": t0Format,
 			},
 		}})
+}
+
+func (*RunnerSuite) TestRunnerReportCancelledContext(c *gc.C) {
+	runner, err := worker.NewRunner(worker.RunnerParams{
+		Name:    "test",
+		IsFatal: noneFatal,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	defer worker.Stop(runner)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	report := runner.Report(ctx)
+	c.Assert(report, gc.IsNil)
 }
 
 type testWorkerStarter struct {
@@ -1005,7 +1020,7 @@ func (t *testWorker) Wait() error {
 	return t.tomb.Wait()
 }
 
-func (t *testWorker) Report() map[string]interface{} {
+func (t *testWorker) Report(ctx context.Context) map[string]interface{} {
 	return t.starter.report
 }
 


### PR DESCRIPTION
This change adds a context parameter in `Report` method and handle gracefully long report request against the engine.

See https://warthogs.atlassian.net/browse/JUJU-9484